### PR TITLE
OT296-65 Modificar endpoint público de organizations para devolver links de redes sociales

### DIFF
--- a/src/main/java/com/alkemy/ong/dto/OrganizationDTOPublic.java
+++ b/src/main/java/com/alkemy/ong/dto/OrganizationDTOPublic.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import javax.persistence.Column;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,4 +14,7 @@ public class OrganizationDTOPublic {
     private String image;
     private String address;
     private Integer phone;
+    private String urlFacebook;
+    private String urlLinkedin;
+    private String urlInstagram;
 }

--- a/src/main/java/com/alkemy/ong/dto/OrganizationDTOPublic.java
+++ b/src/main/java/com/alkemy/ong/dto/OrganizationDTOPublic.java
@@ -1,7 +1,5 @@
 package com.alkemy.ong.dto;
 
-import javax.persistence.Column;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/alkemy/ong/mapper/OrganizationMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/OrganizationMapper.java
@@ -16,6 +16,9 @@ public class OrganizationMapper {
         dtoPublic.setImage(organization.getImage());
         dtoPublic.setPhone(organization.getPhone());
         dtoPublic.setAddress(organization.getAddress());
+        dtoPublic.setUrlFacebook(organization.getUrlFacebook());
+        dtoPublic.setUrlInstagram(organization.getUrlInstagram());
+        dtoPublic.setUrlLinkedin(organization.getUrlLinkedin());
         return dtoPublic;
     }
     public List<OrganizationDTOPublic> organizationListEntity2DTO (List<Organization> organizations){


### PR DESCRIPTION
Devuelve los datos en el endpoint de datos públicos de organización, agregando los campos de redes sociales en la respuesta

<img width="634" alt="image" src="https://user-images.githubusercontent.com/32135161/193329294-ad23717b-8dfd-4b3e-a743-ef129f204eee.png">
