### PR TITLE
OT296-85 Agregar documentación con Swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
 			<artifactId>jjwt</artifactId>
 			<version>0.9.1</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.springdoc</groupId>
+		    <artifactId>springdoc-openapi-ui</artifactId>
+		    <version>1.6.11</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/alkemy/ong/security/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/alkemy/ong/security/configuration/SecurityConfiguration.java
@@ -99,7 +99,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.POST, "/members").hasAnyRole(ROLE_ADMIN)
                 .antMatchers(HttpMethod.PUT, "/members/{id}").hasAnyRole(ROLE_ADMIN)
                 .antMatchers(HttpMethod.DELETE, "/members/{id}").hasRole(ROLE_ADMIN)
-
+                
+                //Docs
+                .antMatchers("/api/docs/**").permitAll()
+                
                 .anyRequest()
                 .authenticated()
                 .and()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,4 @@ jwt.secret=${SECRET}
 jwt.authorization=${AUTHORIZATION}
 #Path for documentation
 springdoc.api-docs.path=/api/docs
+springdoc.swagger-ui.path=/api/docs/swagger-ui-custom.html

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ bucketName=${BUCKET_NAME}
 #JWT
 jwt.secret=${SECRET}
 jwt.authorization=${AUTHORIZATION}
+#Path for documentation
+springdoc.api-docs.path=/api/docs


### PR DESCRIPTION
Implementa la librería Swagger para documentar los diferentes endpoints del proyecto. En el endpoint /api/docs, se muestra el layout. Adicionalmente, se agrega la posibilidad para implementar los diferentes schemas en base a los Comentarios de métodos de cada controlador.

Las rutas son:
/api/docs
/api/docs/swagger-ui-custom.html

![image](https://user-images.githubusercontent.com/32135161/193694545-ed9de364-ae4b-46e8-b993-6827c7ac8119.png)
