### PR TITLE
OT296-84 Agregar paginación a Testimonios

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
+import com.alkemy.ong.dto.PagesDTO;
 import com.alkemy.ong.dto.TestimonialDTO;
 import com.alkemy.ong.service.TestimonialService;
 
@@ -15,9 +16,14 @@ import com.alkemy.ong.service.TestimonialService;
 @RequestMapping("/testimonials")
 public class TestimonialController {
 
-
 	@Autowired
 	private TestimonialService testimonialService;
+
+	@GetMapping(params = "page")
+	public ResponseEntity<?> getPageTestimonial(@RequestParam(defaultValue = "0") int page) {
+		PagesDTO<TestimonialDTO> response = testimonialService.getAllForPages(page);
+		return ResponseEntity.ok().body(response);
+	}
 
 	@PostMapping
 	public ResponseEntity<TestimonialDTO> createTestimonial(@Valid @RequestBody TestimonialDTO testimonial) {

--- a/src/main/java/com/alkemy/ong/mapper/TestimonialMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/TestimonialMapper.java
@@ -1,5 +1,8 @@
 package com.alkemy.ong.mapper;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.alkemy.ong.dto.TestimonialDTO;
@@ -22,5 +25,13 @@ public class TestimonialMapper {
 		testimonialDTO.setImage(testimonial.getImage());
 		testimonialDTO.setName(testimonial.getName());
 		return testimonialDTO; 
+	}
+	
+	public List<TestimonialDTO> testimonialEntityPageDTOList(List<Testimonial> testimonials){
+		List<TestimonialDTO> testimonialDTO = new ArrayList<>();
+		for(Testimonial testimonial: testimonials){
+			testimonialDTO.add(this.testimonialEntity2DTO(testimonial));
+		}
+		return testimonialDTO;
 	}
 }

--- a/src/main/java/com/alkemy/ong/service/TestimonialService.java
+++ b/src/main/java/com/alkemy/ong/service/TestimonialService.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.service;
 
+import com.alkemy.ong.dto.PagesDTO;
 import com.alkemy.ong.dto.TestimonialDTO;
 
 import javassist.NotFoundException;
@@ -7,6 +8,9 @@ import javassist.NotFoundException;
 public interface TestimonialService {
 
 	TestimonialDTO createTestimonial(TestimonialDTO testimonial);
+	
+	public PagesDTO<TestimonialDTO> getAllForPages(int page);
+	
 	TestimonialDTO updateTestimonial(TestimonialDTO dto, String id) throws NotFoundException;
 
 	public void deleteTestimonial(String id) throws NotFoundException;

--- a/src/main/java/com/alkemy/ong/service/implement/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/implement/TestimonialServiceImpl.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.service.implement;
 
+import com.alkemy.ong.dto.PagesDTO;
 import com.alkemy.ong.dto.TestimonialDTO;
 import com.alkemy.ong.service.TestimonialService;
 import com.alkemy.ong.entity.Testimonial;
@@ -9,6 +10,10 @@ import com.alkemy.ong.repository.TestimonialRepository;
 import javassist.NotFoundException;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 
@@ -47,5 +52,23 @@ public class TestimonialServiceImpl implements TestimonialService {
 			throw new NotFoundException("Testimonial not found");
 		}
 		testimonialRepository.deleteById(id);
+	}
+	
+	@Override
+	public PagesDTO<TestimonialDTO> getAllForPages(int page) {
+		if (page < 0) {
+			throw new IllegalArgumentException("Page index must not be less than zero!");
+		}
+		Pageable pageRequest = PageRequest.of(page, 10);
+		Page<Testimonial> testimonial = testimonialRepository.findAll(pageRequest);
+		return responsePage(testimonial);
+	}
+
+	private PagesDTO<TestimonialDTO> responsePage(Page<Testimonial> page) {
+		Page<TestimonialDTO> response = new PageImpl<>(
+				testimonialMapper.testimonialEntityPageDTOList(page.getContent()),
+				PageRequest.of(page.getNumber(), page.getSize()),
+				page.getTotalElements());
+		return new PagesDTO<>(response, "localhost:8080/testimonials?page=");
 	}
 }


### PR DESCRIPTION
Cuando se realiza la petición para listar, los resultados se paginan de a 10. En la respuesta, se muestran los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page

![image](https://user-images.githubusercontent.com/32135161/194679719-82d2337b-91b4-4259-8ef7-7055c0cc8771.png)
