### PR TITLE
OT296-97 Test: Endpoints /authentication

### DIFF
--- a/src/test/java/com/alkemy/ong/security/controller/UserRestControllerTest.java
+++ b/src/test/java/com/alkemy/ong/security/controller/UserRestControllerTest.java
@@ -1,6 +1,9 @@
 package com.alkemy.ong.security.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.alkemy.ong.util.LoginMocksUtil.generateExistentLoginDTO;
+import static com.alkemy.ong.util.LoginMocksUtil.generateFakeLoginDTO;
+import static com.alkemy.ong.util.RegisterMocksUtil.generateRegisterDTO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -25,14 +28,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.alkemy.ong.security.configuration.SecurityConfiguration;
 import com.alkemy.ong.security.dto.LoginDTO;
-import com.alkemy.ong.security.service.UserService;
+import com.alkemy.ong.security.dto.RegisterDTO;
 import com.alkemy.ong.security.service.impl.UserServiceImpl;
 import com.alkemy.ong.security.util.JwTUtil;
 import com.alkemy.ong.utils.OpenAPISecurityConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static com.alkemy.ong.util.LoginMocksUtil.*;
-import static com.alkemy.ong.util.RegisterMocksUtil.*;
 
 @WebMvcTest(UserRestController.class)
 @Import({SecurityConfiguration.class, BCryptPasswordEncoder.class, OpenAPISecurityConfiguration.class})
@@ -50,8 +50,8 @@ class UserRestControllerTest {
 	@MockBean
 	private UserServiceImpl userServiceImpl;
 
-//	@MockBean
-//	private UserService userService;
+	//	@MockBean
+	//	private UserService userService;
 
 	@Autowired
 	private ObjectMapper jsonMapper;
@@ -59,15 +59,18 @@ class UserRestControllerTest {
 	@BeforeEach
 	public void setting(){
 		this.jsonMapper = new ObjectMapper();
-		userServiceImpl.create(generateRegisterDTO());
 	}
 
 	@Nested
 	class meTest{
 		@Test
 		@DisplayName("Valid case")
-		void testMeData() throws Exception {
-			fail("Not yet implemented");
+		void test1() throws Exception {
+			ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/auth/me"))
+					.andExpect(status().isOk())
+					.andDo(MockMvcResultHandlers.print());
+
+			assertEquals(200, result.andReturn().getResponse().getStatus());
 		}
 	}
 
@@ -90,19 +93,16 @@ class UserRestControllerTest {
 		}
 
 		@Test
-		@DisplayName("Invalid Json")
+		@DisplayName("Bad request")
 		void test2() throws Exception {
 			LoginDTO requestBody = generateFakeLoginDTO();
-			
+
 			when(authenticationManager.authenticate(Mockito.any())).thenThrow(new BadCredentialsException("ok false"));
 
 			ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
 					.contentType(MediaType.APPLICATION_JSON)
 					.accept(MediaType.APPLICATION_JSON)
 					.content(jsonMapper.writeValueAsString(requestBody)))
-					//        			.andExpect(status().isForbidden())
-					//        			.andExpect(MockMvcResultMatchers.content().contentType(MediaType.TEXT_PLAIN))
-					//        			.andExpect(MockMvcResultMatchers.content().string("ok: false"))
 					.andDo(MockMvcResultHandlers.print());
 
 			assertEquals(400, result.andReturn().getResponse().getStatus());
@@ -115,11 +115,8 @@ class UserRestControllerTest {
 			ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
 					.contentType(MediaType.APPLICATION_JSON)
 					.accept(MediaType.APPLICATION_JSON)
-					.content(" "));
-			//.andExpect(status().isForbidden())
-			//        			.andExpect(MockMvcResultMatchers.content().contentType(MediaType.TEXT_PLAIN))
-			//        			.andExpect(MockMvcResultMatchers.content().string("ok: false"))
-			//        			.andDo(MockMvcResultHandlers.print());
+					.content(" "))
+					.andDo(MockMvcResultHandlers.print());
 
 			assertEquals(500, result.andReturn().getResponse().getStatus());
 		}
@@ -129,9 +126,17 @@ class UserRestControllerTest {
 	class registerTest{
 		@Test
 		@DisplayName("Valid case")
-		//        @WithMockUser(username = "adminmock@gmail.com", roles = "ADMIN")
-		void testRegister() throws Exception {
-			fail("Not yet implemented");
+		void test1() throws Exception {
+			RegisterDTO requestBody = generateRegisterDTO();
+
+			ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/auth/register")
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON)
+					.content(jsonMapper.writeValueAsString(requestBody)))
+					.andExpect(status().isCreated())
+					.andDo(MockMvcResultHandlers.print());
+
+			assertEquals(201, result.andReturn().getResponse().getStatus());
 		}
 	}
 }

--- a/src/test/java/com/alkemy/ong/security/controller/UserRestControllerTest.java
+++ b/src/test/java/com/alkemy/ong/security/controller/UserRestControllerTest.java
@@ -1,0 +1,133 @@
+package com.alkemy.ong.security.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.alkemy.ong.security.configuration.SecurityConfiguration;
+import com.alkemy.ong.security.dto.LoginDTO;
+import com.alkemy.ong.security.service.UserService;
+import com.alkemy.ong.security.service.impl.UserServiceImpl;
+import com.alkemy.ong.security.util.JwTUtil;
+import com.alkemy.ong.utils.OpenAPISecurityConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static com.alkemy.ong.util.LoginMocksUtil.*;
+import static com.alkemy.ong.util.RegisterMocksUtil.*;
+
+@WebMvcTest(UserRestController.class)
+@Import({SecurityConfiguration.class, BCryptPasswordEncoder.class, OpenAPISecurityConfiguration.class})
+class UserRestControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private AuthenticationManager authenticationManager;
+
+	@MockBean
+	private JwTUtil jwTUtil;
+
+	@MockBean
+	private UserServiceImpl userServiceImpl;
+
+//	@MockBean
+//	private UserService userService;
+
+	@Autowired
+	private ObjectMapper jsonMapper;
+
+	@BeforeEach
+	public void setting(){
+		this.jsonMapper = new ObjectMapper();
+		userServiceImpl.create(generateRegisterDTO());
+	}
+
+	@Nested
+	class meTest{
+		@Test
+		@DisplayName("Valid case")
+		void testMeData() throws Exception {
+			fail("Not yet implemented");
+		}
+	}
+
+	@Nested
+	class loginTest{
+		@Test
+		@DisplayName("Valid case")
+		void test1() throws Exception {
+			LoginDTO requestBody = generateExistentLoginDTO();
+
+			ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON)
+					.content(jsonMapper.writeValueAsString(requestBody)))
+					.andExpect(status().isOk())
+					.andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+//					.andDo(MockMvcResultHandlers.print());
+					;
+
+			assertEquals(200, result.andReturn().getResponse().getStatus());
+		}
+
+		@Test
+		@DisplayName("Invalid Json")
+		void test2() throws Exception {
+			LoginDTO requestBody = generateFakeLoginDTO();
+
+			ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON)
+					.content(jsonMapper.writeValueAsString(requestBody)))
+					//        			.andExpect(status().isForbidden())
+					//        			.andExpect(MockMvcResultMatchers.content().contentType(MediaType.TEXT_PLAIN))
+					//        			.andExpect(MockMvcResultMatchers.content().string("ok: false"))
+					.andDo(MockMvcResultHandlers.print());
+
+			assertEquals(403, result.andReturn().getResponse().getStatus());
+		}
+
+		@Test
+		@DisplayName("Invalid Request")
+		void test3() throws Exception {
+
+			ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON)
+					.content(" "));
+			//.andExpect(status().isForbidden())
+			//        			.andExpect(MockMvcResultMatchers.content().contentType(MediaType.TEXT_PLAIN))
+			//        			.andExpect(MockMvcResultMatchers.content().string("ok: false"))
+			//        			.andDo(MockMvcResultHandlers.print());
+
+			assertEquals(500, result.andReturn().getResponse().getStatus());
+		}
+	}
+
+	@Nested
+	class registerTest{
+		@Test
+		@DisplayName("Valid case")
+		//        @WithMockUser(username = "adminmock@gmail.com", roles = "ADMIN")
+		void testRegister() throws Exception {
+			fail("Not yet implemented");
+		}
+	}
+}

--- a/src/test/java/com/alkemy/ong/security/controller/UserRestControllerTest.java
+++ b/src/test/java/com/alkemy/ong/security/controller/UserRestControllerTest.java
@@ -1,18 +1,21 @@
 package com.alkemy.ong.security.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -81,8 +84,7 @@ class UserRestControllerTest {
 					.content(jsonMapper.writeValueAsString(requestBody)))
 					.andExpect(status().isOk())
 					.andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
-//					.andDo(MockMvcResultHandlers.print());
-					;
+					.andDo(MockMvcResultHandlers.print());
 
 			assertEquals(200, result.andReturn().getResponse().getStatus());
 		}
@@ -91,6 +93,8 @@ class UserRestControllerTest {
 		@DisplayName("Invalid Json")
 		void test2() throws Exception {
 			LoginDTO requestBody = generateFakeLoginDTO();
+			
+			when(authenticationManager.authenticate(Mockito.any())).thenThrow(new BadCredentialsException("ok false"));
 
 			ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/auth/login")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -101,7 +105,7 @@ class UserRestControllerTest {
 					//        			.andExpect(MockMvcResultMatchers.content().string("ok: false"))
 					.andDo(MockMvcResultHandlers.print());
 
-			assertEquals(403, result.andReturn().getResponse().getStatus());
+			assertEquals(400, result.andReturn().getResponse().getStatus());
 		}
 
 		@Test

--- a/src/test/java/com/alkemy/ong/util/LoginMocksUtil.java
+++ b/src/test/java/com/alkemy/ong/util/LoginMocksUtil.java
@@ -1,0 +1,30 @@
+package com.alkemy.ong.util;
+
+import com.alkemy.ong.security.dto.LoginDTO;
+
+public class LoginMocksUtil {
+	
+    public static LoginDTO generateExistentLoginDTO(){
+        LoginDTO loginDTO = new LoginDTO();
+        loginDTO.setEmail("felimune@dev.com");
+        loginDTO.setPassword("pass1234");
+
+        return loginDTO;
+    }
+    
+    public static LoginDTO generateFakeLoginDTO(){
+        LoginDTO loginDTO = new LoginDTO();
+        loginDTO.setEmail("pepe@botellas.com");
+        loginDTO.setPassword("A123");
+
+        return loginDTO;
+    }
+    
+    public static LoginDTO generateRequestMissingMandatoryAttributes(){
+        LoginDTO loginDTO = new LoginDTO();
+        loginDTO.setPassword("userMock123");
+
+        return loginDTO;
+    }
+
+}

--- a/src/test/java/com/alkemy/ong/util/LoginMocksUtil.java
+++ b/src/test/java/com/alkemy/ong/util/LoginMocksUtil.java
@@ -3,28 +3,20 @@ package com.alkemy.ong.util;
 import com.alkemy.ong.security.dto.LoginDTO;
 
 public class LoginMocksUtil {
-	
-    public static LoginDTO generateExistentLoginDTO(){
-        LoginDTO loginDTO = new LoginDTO();
-        loginDTO.setEmail("felimune@dev.com");
-        loginDTO.setPassword("pass1234");
 
-        return loginDTO;
-    }
-    
-    public static LoginDTO generateFakeLoginDTO(){
-        LoginDTO loginDTO = new LoginDTO();
-        loginDTO.setEmail("pepe@botellas.com");
-        loginDTO.setPassword("A123");
+	public static LoginDTO generateExistentLoginDTO(){
+		LoginDTO loginDTO = new LoginDTO();
+		loginDTO.setEmail("felimune@dev.com");
+		loginDTO.setPassword("pass1234");
 
-        return loginDTO;
-    }
-    
-    public static LoginDTO generateRequestMissingMandatoryAttributes(){
-        LoginDTO loginDTO = new LoginDTO();
-        loginDTO.setPassword("userMock123");
+		return loginDTO;
+	}
 
-        return loginDTO;
-    }
+	public static LoginDTO generateFakeLoginDTO(){
+		LoginDTO loginDTO = new LoginDTO();
+		loginDTO.setEmail("pepe@botellas.com");
+		loginDTO.setPassword("A123");
 
+		return loginDTO;
+	}
 }

--- a/src/test/java/com/alkemy/ong/util/RegisterMocksUtil.java
+++ b/src/test/java/com/alkemy/ong/util/RegisterMocksUtil.java
@@ -1,0 +1,16 @@
+package com.alkemy.ong.util;
+
+import com.alkemy.ong.security.dto.RegisterDTO;
+
+public class RegisterMocksUtil {
+
+    public static RegisterDTO generateRegisterDTO(){
+        RegisterDTO registerDTO = new RegisterDTO();
+        registerDTO.setFirstName("Feli");
+        registerDTO.setLastName("Mune");
+        registerDTO.setEmail("felimune@dev.com");
+        registerDTO.setPassword("pass1234");
+
+        return registerDTO;
+    }
+}


### PR DESCRIPTION
Testea el escenario de respuesta correcta y escenarios de error, para todas las rutas /auth exceptuando /auth/user que pertenecen a otro ticket. El archivo se crea dentro de la carpeta /test, con el mismo nombre del controller
<img width="404" alt="image" src="https://user-images.githubusercontent.com/32135161/196711799-4cf801e8-9a81-4c27-b4d6-0ede003019e4.png">
